### PR TITLE
Update distroless to rootless and change nginx default port config

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,28 @@
+name: build-and-test
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  build-and-scan-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build docker image
+        run: |
+          docker build . -t distroless-nginx:${{ github.sha }}
+
+      - name: Install Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.18.3
+
+      - name: Scan image with Trivy 
+        run: |
+          trivy image distroless-nginx:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ shell.
 ## Production
 
 The production version of the distroless do not have any debugging
-tools. 
+tools, container is created to be rootless and nginx default port configuration is updated to port 8000 (security reasons we should not use port lower than 1024).
 
 ## Building
 
@@ -34,6 +34,10 @@ So building:
 This is executed with the command:
 
 `docker run -d --rm -p 80:80 myNginxBuild`
+
+## Nginx configs
+
+Folder nginx_configs contains nginx configuration files which are copied into correct locations to filesystem to be found for nginx when start up.
 
 ## Security stuff
 

--- a/nginx_configs/default.conf
+++ b/nginx_configs/default.conf
@@ -1,0 +1,43 @@
+server {
+    listen       8000;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/nginx_configs/nginx.conf
+++ b/nginx_configs/nginx.conf
@@ -1,0 +1,31 @@
+#user  nonroot;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
- Ngixg config files to nginx_configs (default.conf and nginx.conf)
- Change container port to 8000 (upper than 1024) to prevent root usage
- Nonroot user to get container rootless
- Simple GitHub actions pipeline to build and scan image (will do pushes to ECR at another PR)